### PR TITLE
Allow to regulate size of images in \collaborators

### DIFF
--- a/poster.tex
+++ b/poster.tex
@@ -126,19 +126,20 @@ def foo(a, b):
                 \begin{itemize}
                     \item There are raw links with the full URL \url{https://www.google.com}
                     \item You can add also links with names \href{https://www.google.com}{Google}\\~
-                    
+
             		\item You might also want to write in \hermann{Hermann Bold} - Helmholtz's title font
                 \end{itemize}
             \end{pblock}
         \end{column}
     \end{columns}
 
-    \collaborators{{
-        logos/dlr.pdf, 
-        logos/fzj.pdf, 
-        logos/helmholtz-munich.pdf, 
-        logos/hereon.pdf, 
-        logos/hzdr.pdf, 
+    % optional argument regulates the size of each of the included logos
+    \collaborators[1.0em]{{
+        logos/dlr.pdf,
+        logos/fzj.pdf,
+        logos/helmholtz-munich.pdf,
+        logos/hereon.pdf,
+        logos/hzdr.pdf,
         logos/kit.pdf
     }}
 \end{frame}

--- a/slides.tex
+++ b/slides.tex
@@ -216,7 +216,7 @@ def foo(a, b):
     \reference{
         Foo et al, ``Bar and its theories'', 42, HAICON 24.
     }
-    \collaborators{{logos/dlr.pdf, logos/fzj.pdf, logos/helmholtz-munich.pdf, logos/hereon.pdf, logos/hzdr.pdf, logos/kit.pdf}}
+    \collaborators{{logos/dlr.pdf, logos/fzj.pdf, logos/helmholtz-munich.pdf, logos/hereon.pdf, logos/hzdr.pdf, logos/kit.pdf}}{0.25cm}
 \end{frame}
 
 

--- a/slides.tex
+++ b/slides.tex
@@ -216,7 +216,8 @@ def foo(a, b):
     \reference{
         Foo et al, ``Bar and its theories'', 42, HAICON 24.
     }
-    \collaborators{{logos/dlr.pdf, logos/fzj.pdf, logos/helmholtz-munich.pdf, logos/hereon.pdf, logos/hzdr.pdf, logos/kit.pdf}}{0.25cm}
+    % optional argument regulates the size of each of the included logos
+    \collaborators[0.5cm]{{logos/dlr.pdf, logos/fzj.pdf, logos/helmholtz-munich.pdf, logos/hereon.pdf, logos/hzdr.pdf, logos/kit.pdf}}
 \end{frame}
 
 

--- a/theme/beamerthemehelmholtzai.sty
+++ b/theme/beamerthemehelmholtzai.sty
@@ -32,11 +32,11 @@
 \newcommand{\reference}[1]{%
     \begin{tikzpicture}[remember picture, overlay]
         \node[
-            anchor=south west, 
-            xshift=0.66cm, 
-            yshift=0.3cm, 
-            text=hgfgray, 
-            text width=0.55\paperwidth, 
+            anchor=south west,
+            xshift=0.66cm,
+            yshift=0.3cm,
+            text=hgfgray,
+            text width=0.55\paperwidth,
             align=left,
             inner sep=0,
             execute at begin node=\setlength{\baselineskip}{7pt}
@@ -46,16 +46,16 @@
     \end{tikzpicture}
 }
 
-\newcommand{\collaborators}[1]{%
+\newcommand{\collaborators}[2]{%
     \begin{tikzpicture}[remember picture, overlay]
         \node[
-            anchor=south east, 
-            xshift=-0.4em, 
+            anchor=south east,
+            xshift=-0.4em,
             yshift=1.4em,
             inner sep=0,
         ] at (current page.south east) {
             \foreach \collaborator in #1 {%
-                \hspace{0.2em}\includegraphics[height=0.25cm]{\collaborator}
+                \hspace{0.2em}\includegraphics[height=#2]{\collaborator}
             }
         };
     \end{tikzpicture}

--- a/theme/beamerthemehelmholtzai.sty
+++ b/theme/beamerthemehelmholtzai.sty
@@ -46,7 +46,7 @@
     \end{tikzpicture}
 }
 
-\newcommand{\collaborators}[2]{%
+\newcommand{\collaborators}[2][0.25cm]{%
     \begin{tikzpicture}[remember picture, overlay]
         \node[
             anchor=south east,
@@ -54,8 +54,8 @@
             yshift=1.4em,
             inner sep=0,
         ] at (current page.south east) {
-            \foreach \collaborator in #1 {%
-                \hspace{0.2em}\includegraphics[height=#2]{\collaborator}
+            \foreach \collaborator in #2 {%
+                \hspace{0.2em}\includegraphics[height=#1]{\collaborator}
             }
         };
     \end{tikzpicture}

--- a/theme/beamerthemehelmholtzaiposter.sty
+++ b/theme/beamerthemehelmholtzaiposter.sty
@@ -30,16 +30,16 @@
     \tiny\textcolor{hgfgray50}{Source: #1}
 }
 
-\newcommand{\collaborators}[1]{%
+\newcommand{\collaborators}[2][1.0em]{%
     \begin{tikzpicture}[remember picture, overlay]
         \node[
-            anchor=south east, 
-            xshift=-1.0em, 
+            anchor=south east,
+            xshift=-1.0em,
             yshift=1.0em,
             inner sep=0,
         ] at (current page.south east) {
-            \foreach \collaborator in #1 {%
-                \hspace{0.8em}\includegraphics[height=1.0em]{\collaborator}
+            \foreach \collaborator in #2 {%
+                \hspace{0.8em}\includegraphics[height=#1]{\collaborator}
             }
         };
     \end{tikzpicture}


### PR DESCRIPTION
This adds a second parameter to the `\collaborators` command specifying the size of the graphics included.